### PR TITLE
introduce num parse

### DIFF
--- a/functions/parseQuery.js
+++ b/functions/parseQuery.js
@@ -1,12 +1,15 @@
+const { pad } = require('./stringFunctions')
+
 const textualNumericFieldsDbs = [
 	'ogy2022'
 ]
-const textualNumericFields = [
-	'szavazokorSzama',
-	'kozigEgyseg.megyeKod',
-	'kozigEgyseg.telepulesKod',
-	'kozigEgyseg.evk_lst'
-]
+
+const textualNumericFields = {
+	'szavazokorSzama': 3,
+	'kozigEgyseg.megyeKod': 2,
+	'kozigEgyseg.telepulesKod': 3,
+	'kozigEgyseg.evk_lst': 2,
+}
 
 const toNumeric = string => {
   if (isNaN(+string)) {
@@ -64,8 +67,13 @@ const toDate = string => {
 
 const hasParsed = parsed => typeof parsed !== 'undefined';
 
-const parseQueryValue = (value, key, db) => {
-	if (textualNumericFieldsDbs.includes(db) && textualNumericFields.includes(key)) return value
+const parseQueryValue = (value, key, db, numParse) => {
+	if (textualNumericFieldsDbs.includes(db) && Object.keys(textualNumericFields).includes(key)) {
+		if (numParse) {
+			return pad(value, textualNumericFields[key])
+		 }
+		 return value
+	}
 
   let parsed = toBoolean(value); if (hasParsed(parsed)) return parsed;
   parsed = toNumeric(value); if (hasParsed(parsed)) return parsed;
@@ -75,18 +83,18 @@ const parseQueryValue = (value, key, db) => {
   return value
 }
 
-const parseQuery = (query = {}, db) => (
+const parseQuery = (query = {}, db, numParse) => (
 	Object.entries(query).reduce((acc, [key, value]) => {
     if (Array.isArray(value)){
       return {
         ...acc,
         $and: value.map(v => ({
-          [key]: parseQueryValue(v, key, db)
+          [key]: parseQueryValue(v, key, db, numParse)
         }))
       }
     }
     return {
-      ...acc, [key]: parseQueryValue(value, key, db)
+      ...acc, [key]: parseQueryValue(value, key, db, numParse)
     }
   }, {})
 )

--- a/functions/szkProjectionAndMap.js
+++ b/functions/szkProjectionAndMap.js
@@ -66,7 +66,7 @@ const getProjection = ({ roles }, context) => {
   }
 }
 
-const mapQueryResult = (result, query) => {
+const mapQueryResult = (result, query, numParse) => {
   return result.map(({
     _id,
     __v,
@@ -92,19 +92,24 @@ const mapQueryResult = (result, query) => {
 
   const entry = {
     _id,
-    szavazokorSzama,
+    szavazokorSzama: numParse ? parseInt(szavazokorSzama) : szavazokorSzama,
     kozigEgyseg: {
       _id: kozigEgyseg['_id'],
       ...kozigEgyseg,
+      telepulesKod: numParse ? parseInt(kozigEgyseg.telepulesKod) : kozigEgyseg.telepulesKod,
+      megyeKod: numParse ? parseInt(kozigEgyseg.megyeKod) : kozigEgyseg.megyeKod,
       __v: undefined,
-      link: `/kozigegysegek/${kozigEgyseg['_id']}`
+      linc: `/kozigegysegek/${kozigEgyseg['_id']}`
     },
     szavazokorCime,
     akadalymentes,
     telepulesSzintu,
     szamlKijelolt,
     atjKijelolt,
-    valasztokerulet,
+    valasztokerulet: {
+      ...valasztokerulet,
+      szam: numParse ? parseInt(valasztokerulet.szam) : valasztokerulet.szam
+    },
     kozteruletek: mapKozteruletek(kozteruletek),
     valasztokSzama,
     korzethatar,
@@ -140,10 +145,10 @@ const mapIdResult = (
     szavazohelyisegHelye,
     valasztas,
     __v
-  }, db, kozigEgysegSzavazokoreinekSzama
+  }, db, kozigEgysegSzavazokoreinekSzama, numParse
   ) => ({
     _id,
-    szavazokorSzama,
+    szavazokorSzama: numParse ? parseInt(szavazokorSzama) : szavazokorSzama,
     kozigEgyseg: {
       _id: kozigEgyseg['_id'],
       kozigEgysegNeve: kozigEgyseg.kozigEgysegNeve,
@@ -157,7 +162,10 @@ const mapIdResult = (
     szamlKijelolt,
     atjKijelolt,
     valasztokSzama,
-    valasztokerulet,
+    valasztokerulet: {
+      ...valasztokerulet,
+      szam: numParse ? parseInt(valasztokerulet.szam) : valasztokerulet.szam
+    },
     kozteruletek: mapKozteruletek(kozteruletek),
     helyadatok,
     korzethatar,


### PR DESCRIPTION
Optionally uses integer for numeric fields to make ogy2022 backward compatible by setting `x-num-parse` header param to `true`